### PR TITLE
Updating packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,24 +23,24 @@
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.25.0",
-    "babel-loader": "^7.0.0",
+    "babel-loader": "^7.1.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "chai": "^4.0.2",
-    "enzyme": "^2.8.2",
+    "enzyme": "^2.9.0",
     "jsdoc": "^3.4.3",
     "jsdoc-babel": "^0.3.0",
     "jsdom": "^9.0.0",
     "mocha": "^3.4.2",
-    "react": "^15.6.0",
-    "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.6.0",
+    "react": "^15.6.1",
+    "react-addons-test-utils": "^15.6.0",
+    "react-dom": "^15.6.1",
     "react-formal": "^0.25.4",
     "react-scripts": "^0.9.5",
-    "react-test-renderer": "^15.5.4",
-    "semantic-ui-react": "^0.68.5",
-    "sinon": "^2.3.4",
+    "react-test-renderer": "^15.6.1",
+    "semantic-ui-react": "^0.69.0",
+    "sinon": "^2.3.5",
     "webpack": "^2.6.1",
     "webpack-node-externals": "^1.6.0"
   },
@@ -57,6 +57,6 @@
     "react-input-message": "^0.15.1",
     "react-responsive": "^1.3.0",
     "string-hash": "^1.1.3",
-    "tproptypes": "^0.1.5"
+    "tproptypes": "^0.1.6"
   }
 }


### PR DESCRIPTION
semantic-ui-react  ^0.68.5  →  ^0.69.0
 tproptypes                ^0.1.5  →   ^0.1.6
 babel-loader              ^7.0.0  →   ^7.1.0
 enzyme                    ^2.8.2  →   ^2.9.0
 react                    ^15.6.0  →  ^15.6.1
 react-addons-test-utils  ^15.5.1  →  ^15.6.0
 react-dom                ^15.6.0  →  ^15.6.1
 react-test-renderer      ^15.5.4  →  ^15.6.1
 sinon                     ^2.3.4  →   ^2.3.5